### PR TITLE
toggle web workers for frame requests when blurred

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spotxyz/virtual-background",
-  "version": "0.1.0-custom6",
+  "version": "0.1.0-custom7",
   "description": "Demo on adding virtual background to a live video stream in the browser",
   "homepage": "https://github.com/spotxyz/virtual-background",
   "repository": "https://github.com/spotxyz/virtual-background.git",

--- a/src/core/helpers/frameHelper.ts
+++ b/src/core/helpers/frameHelper.ts
@@ -1,0 +1,92 @@
+// This module is an abstraction over requestAnimationFrame functionality. It toggles between using requestAnimationFrame,
+// and using webworkers to ensure the callbacks continue to be triggered when the tab is backgrounded.
+
+import {cancelWorkerFrame, requestWorkerFrame, setupWorkerTimer} from "./workerHelper";
+
+let worker: Worker | null = null;
+let useWorker = false;
+
+// Always use requestAnimationFrame on the Spot desktop app since we disable background throttling
+const isDesktopApp =
+    typeof window !== 'undefined' && window.navigator.userAgent.includes('Spot/');
+
+interface WrappedCallback {callback: () => void, isWorker: boolean}
+
+let pendingCallbacks: {[x: number]: WrappedCallback} = {};
+
+window.addEventListener('blur', () => {
+    if(isDesktopApp){
+        return; // don't use worker timer on the desktop app
+    }
+
+    if(!useWorker){
+        useWorker = true;
+        console.debug('virtual-background useWorker: '+useWorker);
+
+        if(!worker){
+            worker = setupWorkerTimer();
+        }
+
+        reRequestPendingCallbacks();
+    }
+})
+
+window.addEventListener('focus', () => {
+    if(isDesktopApp){
+        return;
+    }
+
+    if(useWorker){
+        useWorker = false;
+
+        console.log('virtual-background useWorker: '+useWorker);
+
+        if(worker){
+            worker.terminate();
+            worker = null;
+        }
+
+        reRequestPendingCallbacks();
+    }
+})
+
+
+
+export const requestFrame = (callback: () => void) => {
+    let requestId: number = -1;
+
+    let wrappedCallback = () => {
+        if(pendingCallbacks[requestId]){
+            delete pendingCallbacks[requestId];
+            callback();
+        }
+    }
+
+    requestId = useWorker? requestWorkerFrame(wrappedCallback) : requestAnimationFrame(wrappedCallback);
+    pendingCallbacks[requestId] = {callback, isWorker: useWorker};
+
+    return requestId
+}
+
+const reRequestPendingCallbacks =() => {
+    let prevPendingCallbacks = Object.entries(pendingCallbacks);
+    for(let [reqId, wrappedCallback] of prevPendingCallbacks){
+        cancelFrame(parseInt(reqId));
+
+        requestFrame(wrappedCallback.callback);
+    }
+}
+
+
+
+export const cancelFrame = (requestId: number) => {
+    let wrappedCallback = pendingCallbacks[requestId];
+    if(wrappedCallback){
+        if(wrappedCallback.isWorker){
+            cancelWorkerFrame(requestId);
+        }else{
+            cancelAnimationFrame(requestId);
+        }
+        delete pendingCallbacks[requestId];
+    }
+}

--- a/src/core/helpers/workerHelper.ts
+++ b/src/core/helpers/workerHelper.ts
@@ -1,0 +1,44 @@
+// The worker timer functionality here mirrors the requestAnimationFrame api to make them compatible.
+
+// Creates a worker from a function
+const createWorker = (fn: any) => {
+    var blob = new Blob(['self.onmessage = ', fn.toString()], { type: 'text/javascript' });
+    var url = URL.createObjectURL(blob);
+
+    return new Worker(url);
+}
+
+const setWorkerInterval = (callback: () => void) => {
+    function workerFn() {
+      setInterval(function(){
+        postMessage('');
+      }, 1000/24) // 24fps
+    }
+    let worker = createWorker(workerFn);
+    worker.onmessage = callback;
+    worker.postMessage(''); // start the worker
+    return worker;
+}
+
+let workerListeners: (()=>void)[] = [];
+
+export const setupWorkerTimer = () => {
+    let worker = setWorkerInterval(() => {
+        let listenersCopy = workerListeners;
+        workerListeners = []; // clear all listeners
+        listenersCopy.forEach(callback => callback());
+    })
+    return worker;
+}
+
+export const requestWorkerFrame = (callback: () => void) => {
+    let requestId = workerListeners.length;
+    workerListeners.push(callback);
+    return requestId;
+}
+
+export const cancelWorkerFrame = (requestId: number) => {
+    workerListeners.splice(requestId, 1);
+}
+
+

--- a/src/core/hooks/useRenderingPipeline.ts
+++ b/src/core/hooks/useRenderingPipeline.ts
@@ -7,6 +7,7 @@ import { RenderingPipeline } from '../helpers/renderingPipelineHelper'
 import { SegmentationConfig } from '../helpers/segmentationHelper'
 import { SourcePlayback } from '../helpers/sourceHelper'
 import { TFLite } from './useTFLite'
+import { cancelFrame, requestFrame } from "../helpers/frameHelper";
 
 function useRenderingPipeline(
   sourcePlayback: SourcePlayback,
@@ -62,7 +63,7 @@ function useRenderingPipeline(
       beginFrame()
       await newPipeline.render()
       endFrame()
-      renderRequestId = requestAnimationFrame(render)
+      renderRequestId = requestFrame(render)
     }
 
     function beginFrame() {
@@ -100,8 +101,8 @@ function useRenderingPipeline(
     setPipeline(newPipeline)
 
     return () => {
-      shouldRender = false
-      cancelAnimationFrame(renderRequestId)
+      shouldRender = false;
+      cancelFrame(renderRequestId);
       newPipeline.cleanUp()
       console.debug(
         'Animation stopped:',

--- a/src/pipelines/helpers/webglHelper.ts
+++ b/src/pipelines/helpers/webglHelper.ts
@@ -7,6 +7,8 @@
  * to be installed as well.
  * https://marketplace.visualstudio.com/items?itemName=slevesque.shader
  */
+import { requestFrame } from "../../core/helpers/frameHelper";
+
 export const glsl = String.raw
 
 export function createPiplelineStageProgram(
@@ -125,18 +127,18 @@ async function getBufferSubDataAsync(
 
 function clientWaitAsync(gl: WebGL2RenderingContext, sync: WebGLSync) {
   return new Promise<number>((resolve) => {
-    function test() {
+    const test = () => {
       const res = gl.clientWaitSync(sync, 0, 0)
       if (res === gl.WAIT_FAILED) {
         resolve(res)
         return
       }
       if (res === gl.TIMEOUT_EXPIRED) {
-        requestAnimationFrame(test)
+        requestFrame(test);
         return
       }
       resolve(res)
     }
-    requestAnimationFrame(test)
+    requestFrame(test);
   })
 }


### PR DESCRIPTION
Provides a unified requestFrame method which switches between requestAnimationFrame and requestWorkerFrame to ensure renders continue when the tab is backgrounded.